### PR TITLE
fix: button .has-text.has-icon padding

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -320,8 +320,13 @@
 		&.has-text {
 			justify-content: start;
 			padding-right: $grid-unit-15;
-			padding-left: $grid-unit-10;
-			gap: $grid-unit-05;
+			padding-left: $grid-unit-15;
+			gap: $grid-unit-10;
+
+			& > svg {
+				margin-right: -$grid-unit-05;
+				margin-left: -$grid-unit-05;
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit adds a negative margin to the svg of the button when text is present. This provides consistent padding whether the icon is on the left or right of the text.

Fixes: #60734
